### PR TITLE
ResourceChecker handles a situation when GameObject contains MeshFilter, but doesn't contain MeshRenderer

### DIFF
--- a/ResourceChecker.cs
+++ b/ResourceChecker.cs
@@ -725,7 +725,10 @@ public class ResourceChecker : EditorWindow {
 				MissingObjects.Add (tMissing);
 				thingsMissing = true;
 			}
-			if (tMeshFilter.transform.GetComponent<MeshRenderer>().sharedMaterial == null) {
+
+			var meshRenderrer = tMeshFilter.transform.GetComponent<MeshRenderer>();
+				
+			if (meshRenderrer == null || meshRenderrer.sharedMaterial == null) {
 				MissingGraphic tMissing = new MissingGraphic ();
 				tMissing.Object = tMeshFilter.transform;
 				tMissing.type = "material";


### PR DESCRIPTION
It was NullReferenceException thrown before