### PR TITLE
Bugfix: Skip unloaded scenes

### DIFF
--- a/ResourceChecker.cs
+++ b/ResourceChecker.cs
@@ -1024,7 +1024,10 @@ public class ResourceChecker : EditorWindow {
 #else
         List<GameObject> allGo = new List<GameObject>();
         for (int sceneIdx = 0; sceneIdx < UnityEngine.SceneManagement.SceneManager.sceneCount; ++sceneIdx){
-            allGo.AddRange( UnityEngine.SceneManagement.SceneManager.GetSceneAt(sceneIdx).GetRootGameObjects().ToArray() );
+			//only add the scene to the list if it's currently loaded.
+			if (UnityEngine.SceneManagement.SceneManager.GetSceneAt(sceneIdx).isLoaded) {
+				allGo.AddRange(UnityEngine.SceneManagement.SceneManager.GetSceneAt(sceneIdx).GetRootGameObjects().ToArray());
+			}
         }
        
 		allGo.AddRange(GetDontDestroyOnLoadRoots());


### PR DESCRIPTION
Lines 1027-1029: if the scene is unloaded, do not add it to the allGo list.

This allows the script to function even if there are unloaded scenes in the hierarchy.